### PR TITLE
Update make_L2.py

### DIFF
--- a/level2/src/make_L2.py
+++ b/level2/src/make_L2.py
@@ -109,7 +109,7 @@ def doStuff(self, args):
    xhigh  = np.argmin(np.abs(vlsr - -80))
    # integrated intensity from -15.5 km/s to +4.5 km/s
    iilow  = np.argmin(np.abs(vlsr - 4.5)) - xlow
-   iihigh = np.argmin(np.abs(vlsr - -15.5)) - xhigh
+   iihigh = np.argmin(np.abs(vlsr - -15.5)) - xlow
 
    base = np.zeros([n_OTF,xhigh-xlow])
    baseline_fitter = Baseline(x_data=x[xlow:xhigh])


### PR DESCRIPTION
@abegyoung : I was looking at your script to make L2 data, and I think you have a typo in your calculation to create an integrated intensity.  You have created a compressed range of index numbers (down from the full 1024) and then are creating the high and low indicies from which to calculate the integrated intensity.  However, I think you need to calculate these indicies starting from the origin (xlow).  If you use xhigh you can get a negative index number which is out of range. 
Here is what I think the correct patch should be.

-Chris