### PR TITLE
Adapt to new 0.7 format

### DIFF
--- a/level0.8/src/README
+++ b/level0.8/src/README
@@ -1,11 +1,11 @@
 This folder contains source code for the level 0.8 pipeline, first-round deSpur.
 
 example usage of setting channel flags:
-python3 set_bad_ch_flags.py "ACS*_1450*"
+python3 set_bad_ch_flags.py --file "CII*"
 
-Will operate on Bands 1 and 2, from ScanID 14500 - 14509
+Will operate on CII data
 
-Any fits file matching the name ACS3_1450*.fits
+Any fits file matching the name CII*.fits
 
 Will skip files that already have the "set bad channel flag" in HISTORY
 

--- a/level0.8/src/set_bad_chflag.py
+++ b/level0.8/src/set_bad_chflag.py
@@ -24,7 +24,7 @@ def doStuff(scan, args):
     line   = header['LINE']
     # read data_table
     data   = hdu[1].data
-    spec   = data['spec'] 
+    spec   = data['DATA'] 
     nrow   = len(spec)
     CHANNEL_FLAG = data['CHANNEL_FLAG']
 

--- a/level0.8/src/set_noisy_rowflag.py
+++ b/level0.8/src/set_noisy_rowflag.py
@@ -84,7 +84,7 @@ def doStuff(scan, args, ta_std, fitnes, tsys, resgood, resbad):
 
     # READ DATA_TABLE
     data   = hdu[1].data
-    spec   = data['spec'] 
+    spec   = data['DATA'] 
     scan_type = data['scan_type']
     mixer     = data['MIXER']
     unixtime  = data['UNIXTIME']

--- a/level0.8/src/set_noisy_rowflag.py
+++ b/level0.8/src/set_noisy_rowflag.py
@@ -88,7 +88,7 @@ def doStuff(scan, args, ta_std, fitnes, tsys, resgood, resbad):
     scan_type = data['scan_type']
     mixer     = data['MIXER']
     unixtime  = data['UNIXTIME']
-    THOT      = data['THOT']
+    THOT      = header['THOT']
     ROW_FLAG  = data['ROW_FLAG']
 
     if(line=='NII'):


### PR DESCRIPTION
Fix level 0.8 scripts to accommodate new 0.7 format
There are a few subtle differences in Craig's new level 0.7 data format.  I'm adjusting Abe's scripts to handle them.  Most importantly the data is now stored in the HDU as "DATA" rather than "spec"