### PR TITLE
Updates level05 level07

### DIFF
--- a/common/flagdefs.py
+++ b/common/flagdefs.py
@@ -41,7 +41,8 @@ class SeqFlags(IntFlag):
     MISSING_HK = auto()
     MAYBE_HUNG_LO = auto()
     MISSING_HOT = auto()
-    MISSING_REF = auto()
+    MISSING_LEADING_REF = auto()
+    MISSING_TRAILING_REF = auto()
     NOREFS = auto()
     NODATA = auto()
     

--- a/level0.5/run_level05.sh
+++ b/level0.5/run_level05.sh
@@ -1,42 +1,47 @@
 #!/usr/bin/env bash
 
 cpus=1
-clean=0
+erase=0
+outDir='./build'
 
-while getopts "ej:f:" flag
+while getopts "ej:f:o:" flag
 do
     case "${flag}" in
 	e) erase=1;;
         j) cpus=${OPTARG};;
 	f) list=${OPTARG};;
+	o) outDir=${OPTARG};;
     esac
 done
 
 echo "# of CPUs: $cpus"
 echo "file list: ${list}"
+echo "Output base path: ${outDir}"
 
 if [ ! -f $list ]; then
     echo "$list does not exist. Sorry."
     exit
 fi
 
+mkdir -p $outDir/B1
+mkdir -p $outDir/B2
+
 if [ $erase -eq 1 ]; then
-    echo "Cleaning destination directory..."
-    rm -f build/B1/*.fits
-    rm -f build/B2/*.fits
+    echo "Cleaning destination B1 and B2 directories..."
+    rm -f ${outDir}/B1/*.fits
+    rm -f ${outDir}/B2/*.fits
 fi
 rm -f x??
-sync
 
 if [ $cpus -eq 1 ]; then
     echo "Running corrspec on $list in uniprocessor mode"
-    time ./src/corrspec $list 
+    time ./src/corrspec $list $outDir
 else
     total_lines=$(wc -l <$list)
     ((lines_each = (total_lines + cpus - 1) / cpus))
     split -l $lines_each $list x
     for file in x??; do
 	echo "Running corrspec on $file in parallel"
-	time ./src/corrspec $file &
+	time ./src/corrspec $file $outDir &
     done
 fi

--- a/level0.5/src/callback.c
+++ b/level0.5/src/callback.c
@@ -81,7 +81,7 @@ void append_to_fits_table(const char *filename, struct s_header *fits_header, do
     fitsfile *fptr;  // FITS file pointer
     int array_length, band, npix, seqflag = 0, status = 0; // CFITSIO status must be initialized
     long nrows;
-    char extname[] = "DATA_TABLE", proctime[256], comment[256], line[4], version[] = "20250224";
+    char extname[] = "DATA_TABLE", proctime[256], comment[256], line[4], version[] = "20250306";
     float linefreq, dlevel=0.5;
     
     // Try to open the FITS file in read/write mode. If it doesn't exist, create a new one.
@@ -275,7 +275,7 @@ void printDateTimeFromEpoch(time_t ts)
 }
 
 // Callback function to process the file
-void callback(char *filein){
+void callback(char *filein, char *dirOut){
    char *fullpath= malloc(128*sizeof(char));
    strcpy(fullpath, filein); // make a copy leaving filein intact for later tokenization
    char *datafile; // filename with no path, for header
@@ -586,9 +586,9 @@ void callback(char *filein){
 
       char fitsfile[32];
       if(UNIT == 4) // band 2
-	 sprintf(fitsfile, "./build/B2/ACS%d_%s_%05d.fits", UNIT-1, prefix, scanID);
+	 sprintf(fitsfile, "%s/B2/ACS%d_%s_%05d.fits", dirOut, UNIT-1, prefix, scanID);
       else if (UNIT == 6) // band 1
-	 sprintf(fitsfile, "./build/B1/ACS%d_%s_%05d.fits", UNIT-1, prefix, scanID);
+	 sprintf(fitsfile, "%s/B1/ACS%d_%s_%05d.fits", dirOut, UNIT-1, prefix, scanID);
       if (DEBUG)
          printf("%s\n", fitsfile);
       append_to_fits_table(fitsfile, fits_header, array); 

--- a/level0.5/src/callback.h
+++ b/level0.5/src/callback.h
@@ -2,18 +2,17 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdint.h>
-#include <it/math.h>
 #include <fftw3.h>
 #include <stdbool.h>
 #include <curl/curl.h>
 #include <fitsio.h>
 
-// make sure these are consistent with later flagdefs.py in ./common
+// make sure these are consistent with flagdefs.py in ../common for Level 0.7+
 #define DAC_CAL_FIXED 25
 #define DAC_CAL_EFFED 31
 
 // function to process correlator lag file
-void callback(char *filein);
+void callback(char *, char *);
 
 // structure to hold QC correction coefficients
 struct coeffs {

--- a/level0.5/src/corrspec.c
+++ b/level0.5/src/corrspec.c
@@ -1,5 +1,6 @@
 #include "corrspec.h"
 #include "callback.h"
+#include <sys/stat.h>
 
 extern struct coeffs c;
 char commit_info[256];
@@ -38,13 +39,23 @@ void get_git_commit_info(const char *filename, char *commit_info) {
     snprintf(commit_info, BUFSIZ+sizeof(filename), "%s %s", filename, hash);
 }
 
+
 int main(int argc, char **argv) {
    // Set up SIGSEGV handler
    FILE *fp;
-   char fileName[128];
+   char fileName[128], outputPath[128]="./build";
 
+   if(argc < 2)
+     {
+       printf("Syntax:\n\t./corrspec <file list> <optional output directory>\n");
+       return 1;
+     }
+   else if(argc == 3)
+     sprintf(outputPath, "%s", argv[2]);
+   
+   printf("Using output directories: %s/B1 and %s/B2\n", outputPath, outputPath);
+   
    c.len = readQCfile();
-   // get git versioning once at start
    get_git_commit_info("./src/callback.c", commit_info);
    
    // Setup all possible FFTW array lengths
@@ -58,8 +69,7 @@ int main(int argc, char **argv) {
 
    fp = fopen(argv[1], "r");
    while(fscanf(fp,"%s", fileName) != EOF)
-      callback(fileName);
+     callback(fileName, outputPath);
    fclose(fp);
    return 0;
 }
-

--- a/level0.7/src/L07-pipeline.py
+++ b/level0.7/src/L07-pipeline.py
@@ -108,6 +108,8 @@ def checkSequence(fileList):
     scanID = []
     isHOTREF = []
     num = [0,0,0,0]
+    foundUpperREF = False
+    foundLowerREF = False
     
     for x in fileList:
         scanID.append(int(x[-10:-5]))
@@ -117,11 +119,26 @@ def checkSequence(fileList):
     for y in range(0,4):
         num[y] = type.count(typeStr[y])
 
-    if(num[REF] < 2):
-        seqFlag |= flagdefs.SeqFlags.MISSING_REF
-        if(num[REF] == 0):
-            print("ERROR: no REFs found")
-            seqFlag |= flagdefs.SeqFlags.NOREFS
+    if(num[REF] == 0):
+        print("ERROR: no REFs found")
+        seqFlag |= flagdefs.SeqFlags.NOREFS
+    elif(num[REF] > 0 and num[REF] < 2):
+        index = type.index('OTF')
+        OTFscanID = scanID[index]
+        refList= [i for i,e in enumerate(type) if e == 'REF']
+        for item in refList:
+            if scanID[item] < OTFscanID:
+                foundLowerREF = True
+            elif scanID[item] > OTFscanID:
+                foundUpperREF = True
+        if foundLowerREF == False:
+            seqFlag |= flagdefs.SeqFlags.MISSING_LEADING_REF
+            print("MISSING_LEADING_REF")
+        elif foundUpperREF == False:
+            seqFlag |= flagdefs.SeqFlags.MISSING_TRAILING_REF
+            print("MISSING_TRAILING_REF")
+        else:
+            print("ERROR: inconsistent REF count")
     if(num[OTF] == 0 and num[APS] == 0):
         print("ERROR: no data!")
         seqFlag |= flagdefs.SeqFlags.NODATA


### PR DESCRIPTION
Here are the accumulated improvements and fixes to Level 0.5 and Level 0.7:

1. Level 0.5:  fix errant variable in the run_level05.sh script (found by Russ).  Also removed the `sync` call in the script.  Closes issue #45 and issue #40.

2. Level 0.5:  Add runtime support to set the output Level 0.7 FITS base directory where you want.  The default, if the '-o' option is not set, is to continue to use the in-tree "build" folder.   The output directories will be created if they are not present.   The '-e' "erase" option will apply to whatever base directory is specified by '-o'.   

Example:  

`% time ./run_level05.sh -e -j 2 -f fileList.txt -o /home/obs/data/GUSTO/level0.5`

will put B1 data in `/home/obs/data/GUSTO/level0.5/B1` and B2 data in `/home/obs/data/GUSTO/level0.5/B2`

3. Level 0.7:  The data from mid-February had a higher occurrence of files that failed the insertion of fast housekeeping into the binary table (e.g. mixer and LO biases).   This was fixed by adding a small buffer to the time values for the influx query.  

4. Level 0.7:  In issue #42 it was requested that Level 0.7 not just return a sequence flag indicating whether a REF might be missing, but to indicate whether it is a leading REF or a trailing REF.   This has been done and captured in the updated sequence flags definitions.

5. Level 0.7:  We accidentally lost the name of HDU[1] => 'DATA_TABLE' from Level 0.5.  Re-assert it.

6. Level 0.7:  We were previously pulling the object name from the tuning table (IF.txt) but this isn't robust enough.  We more correctly pull it from the gondola log (sequences file).  Closes issue #43

7. Level 0.7: Regenerate the sequences file if it is of zero length.   This is hardly failsafe but it is better than just checking only the existence of the file.

8. Both Level 0.5 and Level 0.7 manual "version" numbers are now "20250306".
